### PR TITLE
Created custom safety exceptions 

### DIFF
--- a/src/iarc7_safety/iarc_safety_exception.py
+++ b/src/iarc7_safety/iarc_safety_exception.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+class IARCSafetyException(RuntimeError):
+    pass
+
+class IARCFatalSafetyException(IARCSafetyException):
+    pass


### PR DESCRIPTION
Two types of new exceptions: 
- IARCSafetyException that inherits from RuntimeError and is considered non-fatal
- IARCFatalSafetyException that inherits from IARCSafetyException and is considered fatal